### PR TITLE
Merge fix from aheckmann/node-ses#2.0.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,16 @@
+2.0.3 / 2016-12-09
+===================
+
+[BUG FIXES]
+
+ * Really release fix from 2.0.2 (@lyuzashi)
+
+2.0.2 / 2016-12-05
+===================
+
+[BUG FIXES]
+
+ * Fix syntax issue which could break builds in some cases (@otech47)
 
 2.0.0 / 2016-08-16
 ==================

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -47,7 +47,6 @@ function SESClient (options) {
   this.key = expect(options, 'key');
   this.secret = expect(options, 'secret');
   this.amazon = options.amazon || exports.amazon;
-`https://email.us-east-1.amazonaws.com`
 }
 
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "any-promise"
   ],
   "name": "node-ses-any-promise",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "url": "https://github.com/haoliangyu/node-ses-any-promise.git"
   },


### PR DESCRIPTION
@aheckmann kindly fixed https://github.com/aheckmann/node-ses/issues/39, where a rogue no-op template literal caused a syntax error in non-ES6 interpreters.

I'd like to remove the line from the Any Promise fork to prevent the same issue with this library.